### PR TITLE
Added SECURITY DFINER to versioning() and set_system_time().

### DIFF
--- a/temporal_tables--1.1.0.sql
+++ b/temporal_tables--1.1.0.sql
@@ -6,7 +6,7 @@
 CREATE FUNCTION versioning()
 RETURNS TRIGGER
 AS 'MODULE_PATHNAME'
-LANGUAGE C STRICT;
+LANGUAGE C STRICT SECURITY DEFINER;
 
 REVOKE ALL ON FUNCTION versioning() FROM PUBLIC;
 
@@ -15,6 +15,6 @@ COMMENT ON FUNCTION versioning() IS 'System-period temporal table trigger';
 CREATE FUNCTION set_system_time(timestamptz)
 RETURNS VOID
 AS 'MODULE_PATHNAME'
-LANGUAGE C;
+LANGUAGE C SECURITY DEFINER;
 
 COMMENT ON FUNCTION set_system_time(timestamptz) IS 'Set the system time used by versioning triggers to the specific value. NULL reverts back to the default behaviour and uses CURRENT_TIMESTAMP';


### PR DESCRIPTION
I've added SECURITY DEFINER to the exported functions in temporal tables to support row-level security features in Postgres 9.5. I have a motivating example [here](https://github.com/SMRxT/postgrest-demo/blob/events/db/deploy/postgrest/tables/event-space.sql). The goal is to use row-level security to enable a role to have full control over their data on a table of current values, and be able to fully query their history. However, they should be completely unable to manually make edits to their own data if it resides in the history table.

With this setup and the current version of temporal tables, the test script [here](https://github.com/SMRxT/postgrest-demo/blob/events/db/verify/postgrest/tables/event-space.sql) produces the following error.

```
Verifying postgrest_demo
  * public/extensions/uuid-ossp ................. ok
  * postgrest/schema ............................ ok
  * postgrest/roles/anonymous ................... ok
  * postgrest/roles/account ..................... ok
  * postgrest/tables/account .................... ok
  * postgrest/functions/register ................ ok
  * postgrest/functions/get-current-account-id .. ok
  * postgrest/tables/private-logs @v1.0.0 ....... ok
  * public/extensions/temporal-tables ........... ok
  * postgrest/tables/event-space ................ psql:verify/postgrest/tables/event-space.sql:52: WARNING:  system period value of relation "event_space" was adjusted
CONTEXT:  SQL statement "DELETE
   FROM event_space
   WHERE event_space_id = esid"
PL/pgSQL function inline_code_block line 37 at SQL statement
psql:verify/postgrest/tables/event-space.sql:52: ERROR:  permission denied for relation event_space_history
CONTEXT:  SQL statement "INSERT INTO postgrest.event_space_history (event_space_id, name, address, description, valid_between, owned_by) VALUES ($1, $2, $3, $4, $5, $6)"
SQL statement "DELETE
   FROM event_space
   WHERE event_space_id = esid"
PL/pgSQL function inline_code_block line 37 at SQL statement
# Verify script "verify/postgrest/tables/event-space.sql" failed.
not ok

Verify Summary Report
---------------------
Changes: 10
Errors:  1
Verify failed
```

This occurs because the Postgres default is to run a function as SECURITY INVOKER, and the current role does not have the rights to edit its own history table. Switching to SECURITY DEFINER would make this example possible.

---

Please let me know if I need to do anything to comply with your versioning rules or code conventions.

Additional Interested Parties: @joeandaverde, @smerchek.