### PR TITLE
Correct trigger definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 CREATE TRIGGER employees_delete
-BEFORE INSERT ON employees_history
+BEFORE DELETE ON employees_history
 FOR EACH ROW EXECUTE PROCEDURE employees_delete();
 ```
 


### PR DESCRIPTION
It looks to me that the 'employees_delete' trigger definition should have BEFORE DELETE instead of BEFORE INSERT.