### PR TITLE
Revert "Correct trigger definition"

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 CREATE TRIGGER employees_delete
-BEFORE DELETE ON employees_history
+BEFORE INSERT ON employees_history
 FOR EACH ROW EXECUTE PROCEDURE employees_delete();
 ```
 


### PR DESCRIPTION
This reverts commit b7f682ae5581f85ec94e4326f6ad0837a346f435.

The trigger was on insert to the *history* table, not the main
table. Triggering on delete to the history table doesn’t make
sense and it’ll always error because the function uses `NEW`.

The original example is a little unclear. It records the user
who caused a history entry to be created, so it is saving which
user was responsible for deleting the *old state* of the record,
rather than recording only when a user deletes a record with a
`DELETE` on the main table.